### PR TITLE
Updated tide_core for Maxlength module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_api": "1.2.12",
-        "dpc-sdp/tide_core": "1.2.14",
+        "dpc-sdp/tide_core": "1.4.0",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
         "dpc-sdp/tide_media": "1.2.6",


### PR DESCRIPTION
drupal/maxlength doesn't need https://www.drupal.org/project/maxlength/issues/2798903 patch. 

relates to 
1. https://github.com/dpc-sdp/tide_core/pull/98
2. https://github.com/dpc-sdp/tide_core/blob/1.4.0/composer.json