### PR TITLE
SDPA-2673 updates tide_media

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "dpc-sdp/tide_core": "1.4.0",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
-        "dpc-sdp/tide_media": "1.3.1",
+        "dpc-sdp/tide_media": "1.3.2",
         "dpc-sdp/tide_monsido": "1.1.5",
         "dpc-sdp/tide_news": "1.1.6",
         "dpc-sdp/tide_page": "1.2.6",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "dpc-sdp/tide_core": "1.4.0",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
-        "dpc-sdp/tide_media": "1.2.6",
+        "dpc-sdp/tide_media": "1.3.1",
         "dpc-sdp/tide_monsido": "1.1.5",
         "dpc-sdp/tide_news": "1.1.6",
         "dpc-sdp/tide_page": "1.2.6",


### PR DESCRIPTION
Releasing new tide profile to update tide_media

### Changes
1. added a hook_update to enable the field in form_display of all media bundles.

Jira: https://digital-engagement.atlassian.net/browse/SDPA-2673

more details: https://github.com/dpc-sdp/tide_media/pull/27 and https://github.com/dpc-sdp/tide_media/releases/tag/1.3.1