### PR TITLE
Release/1.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_api": "1.2.12",
-        "dpc-sdp/tide_core": "1.4.0",
+        "dpc-sdp/tide_core": "1.4.4",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
-        "dpc-sdp/tide_media": "1.3.2",
+        "dpc-sdp/tide_media": "1.4.0",
         "dpc-sdp/tide_monsido": "1.1.5",
         "dpc-sdp/tide_news": "1.1.6",
         "dpc-sdp/tide_page": "1.2.6",


### PR DESCRIPTION
1. Removing the dependency on the drupal:page_cache module. (#112)
2. changes scan_module to 1 (#114)
3. adds tide_media_file_overwrite submodule