### PR TITLE
Updates tide_core to 1.5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_api": "1.4.0",
-        "dpc-sdp/tide_core": "1.5.0",
+        "dpc-sdp/tide_core": "1.5.2",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
         "dpc-sdp/tide_media": "1.5.0",


### PR DESCRIPTION
1. includes queue_mails module
2. Removes smart_trim patch merged into the latest release