### PR TITLE
Bump Drupal Core to 8.7.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_api": "1.4.0",
-        "dpc-sdp/tide_core": "dev-feature/bump_drupal_core as 1.5.2",
+        "dpc-sdp/tide_core": "1.5.3",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
         "dpc-sdp/tide_media": "1.5.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_api": "1.4.0",
-        "dpc-sdp/tide_core": "1.5.2",
+        "dpc-sdp/tide_core": "dev-feature/bump_drupal_core",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
         "dpc-sdp/tide_media": "1.5.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_api": "1.4.0",
-        "dpc-sdp/tide_core": "dev-feature/bump_drupal_core",
+        "dpc-sdp/tide_core": "dev-feature/bump_drupal_core as 1.5.2",
         "dpc-sdp/tide_event": "1.2.8",
         "dpc-sdp/tide_landing_page": "1.1.11",
         "dpc-sdp/tide_media": "1.5.0",

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=a06d079ad232a38cf4cc39feaa4dd8f1df3fe9e2
+export GH_COMMIT=eade89171ec349c8a49c47cf94820b1724f033bf
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"


### PR DESCRIPTION
### Changed
1.  Bumped version of Drupal Core 8.7.11

### Related PRs
dpc-sdp/content-vic-gov-au#760
dpc-sdp/tide_core#122
