### PR TITLE
update tide_media because of a Security update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "dpc-sdp/tide_event_atdw": "1.0.0",
         "dpc-sdp/tide_grant": "1.0.0",
         "dpc-sdp/tide_landing_page": "1.2.2",
-        "dpc-sdp/tide_media": "1.5.2",
+        "dpc-sdp/tide_media": "1.5.3",
         "dpc-sdp/tide_monsido": "1.1.5",
         "dpc-sdp/tide_news": "1.1.6",
         "dpc-sdp/tide_page": "1.2.6",


### PR DESCRIPTION
### Changes
1. update tide_media module
     - update svg_image module based on [sa-contrib-2020-008](https://www.drupal.org/sa-contrib-2020-008) reason.

https://github.com/dpc-sdp/tide_media/pull/38
https://github.com/dpc-sdp/tide_media/releases/tag/1.5.3