### PR TITLE
Revert "[SDPA-4396] Bumped dev-tools pointer."

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=b47361ea10b5c363dd7c0179954eadbf47ce6ba7
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"


### PR DESCRIPTION
This reverts commit 509afa8971e7305adfcef0c058f045dfcf6b660e.

Prior to the release of dpc-sdp/dev-tools 0.4.2 it was necessary to reference the commit that incremented Drupal Core to 8.8.8 so that tests would pass.