### PR TITLE
Adds required(?) dependencies.

### DIFF
--- a/tide.info.yml
+++ b/tide.info.yml
@@ -6,6 +6,7 @@ core: '8.x'
 dependencies:
   - dpc-sdp:tide_core
   - dpc-sdp:tide_api
+  - dpc-sdp:tide_alert
   - dpc-sdp:tide_media
   - dpc-sdp:tide_webform
   - dpc-sdp:tide_event


### PR DESCRIPTION
This resolves a fatal PHP error when installing `tide_demo_content` after a fresh install.