### PR TITLE
Release 1.5.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "require": {
         "dpc-sdp/tide_alert": "1.0.3",
         "dpc-sdp/tide_api": "1.5.1",
-        "dpc-sdp/tide_authenticated_content": "1.0.3",
-        "dpc-sdp/tide_core": "1.6.12",
-        "dpc-sdp/tide_demo_content": "1.1.3",
+        "dpc-sdp/tide_authenticated_content": "1.0.4",
+        "dpc-sdp/tide_core": "1.6.13",
+        "dpc-sdp/tide_demo_content": "1.1.4",
         "dpc-sdp/tide_event": "1.3.5",
         "dpc-sdp/tide_event_atdw": "1.0.0",
         "dpc-sdp/tide_grant": "1.0.5",


### PR DESCRIPTION
Release 1.5.20
- tide_demo_content
  1. Updated the summary field name for the introduction banner in demo landing page contents.(#9 )
- tide_authenticated_content
  1. User Roles can be blocked from log in
- tide_core
  1. Added CKeditor liststyle module.
  2. Removed permissions for editor to access redirects.