### PR TITLE
[SDPA-4996] Removed tide_authenticated_content from composer json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "dpc-sdp/tide_alert": "1.0.5",
         "dpc-sdp/tide_api": "1.5.4",
-        "dpc-sdp/tide_authenticated_content": "2.0.2",
         "dpc-sdp/tide_core": "2.0.4",
         "dpc-sdp/tide_demo_content": "1.1.6",
         "dpc-sdp/tide_event": "1.3.6",


### PR DESCRIPTION
### JIRA
https://digital-engagement.atlassian.net/browse/SDPA-4996

### Changed
Removed tide_authenticated_content from composer JSON as this is no longer required for all the SDP projects.

### Related PRs - 
baywatch - https://github.com/dpc-sdp/baywatch/pull/18
Ansible task - https://github.com/dpc-sdp/sdp-ansible-upgrade/pull/59