### PR TITLE
update version tide core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "dpc-sdp/tide_alert": "1.0.5",
         "dpc-sdp/tide_api": "1.5.4",
         "dpc-sdp/tide_authenticated_content": "2.0.2",
-        "dpc-sdp/tide_core": "2.0.6",
+        "dpc-sdp/tide_core": "2.0.7",
         "dpc-sdp/tide_demo_content": "1.1.6",
         "dpc-sdp/tide_event": "1.3.6",
         "dpc-sdp/tide_event_atdw": "1.0.1",


### PR DESCRIPTION
Motivation:
Based on PR https://github.com/dpc-sdp/tide_core/pull/222 .
Updating tide core version to latest Release/2.0.7 
