### PR TITLE
Restores tide_event_atdw

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "dpc-sdp/tide_core": "2.0.15",
         "dpc-sdp/tide_demo_content": "1.1.7",
         "dpc-sdp/tide_event": "1.3.7",
-        "dpc-sdp/tide_event_atdw": "1.0.2",
+        "dpc-sdp/tide_event_atdw": "1.0.3",
         "dpc-sdp/tide_grant": "1.0.10",
         "dpc-sdp/tide_landing_page": "2.0.8",
         "dpc-sdp/tide_media": "1.7.11",

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "dpc-sdp/tide_core": "2.0.15",
         "dpc-sdp/tide_demo_content": "1.1.7",
         "dpc-sdp/tide_event": "1.3.7",
+        "dpc-sdp/tide_event_atdw": "1.0.2",
         "dpc-sdp/tide_grant": "1.0.10",
         "dpc-sdp/tide_landing_page": "2.0.8",
         "dpc-sdp/tide_media": "1.7.11",


### PR DESCRIPTION
### Motivation
removing tide_event_atdw contains 2 steps:
1.  disable `tide_event_atdw` module from all sites.
2. remove it from `tide` profile. 

### Changes
1. restores tide_event_atdw is for doing step 1.