### PR TITLE
Release/3.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "dpc-sdp/tide_event_atdw": "3.0.0",
         "dpc-sdp/tide_grant": "3.0.0",
         "dpc-sdp/tide_landing_page": "3.0.0",
-        "dpc-sdp/tide_media": "3.0.1",
+        "dpc-sdp/tide_media": "3.0.2",
         "dpc-sdp/tide_monsido": "3.0.0",
         "dpc-sdp/tide_news": "3.0.0",
         "dpc-sdp/tide_page": "3.0.0",


### PR DESCRIPTION
### Change
tide_media was somehow missed from tide 3.0.2 release https://github.com/dpc-sdp/tide/pull/159

Bump tide_media to 3.0.2 https://github.com/dpc-sdp/tide_media/releases/tag/3.0.2