### PR TITLE
[SDPA-5959] Add Tide CMS Help block to Admin theme

### DIFF
--- a/config/install/block.block.seven_tide_cms_help.yml
+++ b/config/install/block.block.seven_tide_cms_help.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - tide_cms_support
+  theme:
+    - seven
+id: seven_tide_cms_help
+theme: seven
+region: help
+weight: -100
+provider: null
+plugin: tide_help_block
+settings:
+  id: tide_help_block
+  label: 'Tide CMS Help'
+  provider: tide_cms_support
+  label_display: ''
+visibility: {  }


### PR DESCRIPTION
Ticket: https://digital-engagement.atlassian.net/browse/SDPA-5959

## Changes

- Install the Tide CMS Help block to the Admin theme

## Motivation

During fresh install of `tide` profile we can place CMS Help block into the admin theme where it is used to display contextual Tide Help content above specific admin forms, pages and routes. 

## Related

- dpc-sdp/tide_core#323