### PR TITLE
release/3.0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "dpc-sdp/tide_event": "3.0.0",
         "dpc-sdp/tide_event_atdw": "3.0.0",
         "dpc-sdp/tide_grant": "3.0.0",
-        "dpc-sdp/tide_landing_page": "3.0.3",
+        "dpc-sdp/tide_landing_page": "3.0.4",
         "dpc-sdp/tide_media": "3.0.5",
         "dpc-sdp/tide_monsido": "3.0.0",
         "dpc-sdp/tide_news": "3.0.2",


### PR DESCRIPTION
Updated tide_landing_page
[SRM-403] Fix Stat Grid 2 default blocks not showing 

[SRM-403]: https://digital-engagement.atlassian.net/browse/SRM-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ