### PR TITLE
[SDPAP-6350] Added code to remove default unused views.

### DIFF
--- a/tide.install
+++ b/tide.install
@@ -49,4 +49,15 @@ function tide_install() {
   if (file_exists(DRUPAL_ROOT . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'contrib' . DIRECTORY_SEPARATOR . 'redis')) {
     \Drupal::service('module_installer')->install(['redis']);
   }
+  // These viewes are replaced by custom views provided by tide_site.
+  $view_ids = [
+    'content',
+    'moderated_content',
+  ];
+  foreach ($view_ids as $view_id) {
+    $view = \Drupal::entityTypeManager()->getStorage('view')->load($view_id);
+    if ($view) {
+      $view->setStatus(FALSE)->save();
+    }
+  }
 }


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-6350

### Issue
1. the 'content' and 'moderated_content' view is replaced by 'summary_contents_filters' and 'tide_site_moderated_content_filters' view but it still gets enabled during fresh install
2. These two views can not be disabled from other tide modules as the time those modules are installed, these default view wasn't set properly to be disabled.

### Changes
Added in the tide profile install hook. Because Install hooks in profiles were so far only called when a site was installed and after all the listed modules were installed and all the configuration was imported. ([reference](https://www.drupal.org/project/drupal/issues/2982052))

### Related PRs
tide_core - https://github.com/dpc-sdp/tide_core/pull/330
tide_site_restriction - https://github.com/dpc-sdp/tide_site_restriction/pull/38