### PR TITLE
Release/3.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "dpc-sdp/tide_alert": "3.0.2",
         "dpc-sdp/tide_api": "3.0.9",
         "dpc-sdp/tide_authenticated_content": "3.0.6",
-        "dpc-sdp/tide_core": "3.2.4",
+        "dpc-sdp/tide_core": "3.2.5",
         "dpc-sdp/tide_demo_content": "3.0.10",
         "dpc-sdp/tide_event": "3.0.2",
         "dpc-sdp/tide_event_atdw": "3.0.1",
@@ -20,7 +20,7 @@
         "dpc-sdp/tide_profile": "3.0.1",
         "dpc-sdp/tide_publication": "3.0.3",
         "dpc-sdp/tide_search": "3.0.6",
-        "dpc-sdp/tide_site": "3.0.12",
+        "dpc-sdp/tide_site": "3.0.13",
         "dpc-sdp/tide_test": "3.0.2",
         "dpc-sdp/tide_webform": "3.0.9"
     },


### PR DESCRIPTION
Includes the sitemap 4.x update.
  https://github.com/dpc-sdp/tide_site/releases/tag/3.0.13
  https://github.com/dpc-sdp/tide_core/releases/tag/3.2.5