### PR TITLE
[DDS-1474] Bump tide_core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "dpc-sdp/tide_alert": "3.0.2",
         "dpc-sdp/tide_api": "3.0.11",
         "dpc-sdp/tide_authenticated_content": "3.0.8",
-        "dpc-sdp/tide_core": "3.2.11",
+        "dpc-sdp/tide_core": "3.2.12",
         "dpc-sdp/tide_demo_content": "3.0.12",
         "dpc-sdp/tide_event": "3.0.4",
         "dpc-sdp/tide_event_atdw": "3.0.1",


### PR DESCRIPTION
1) Bump tide_core to pull in https://github.com/dpc-sdp/tide_core/releases/tag/3.2.12.