### PR TITLE
3.2.23-p1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "dpc-sdp/tide_alert": "3.0.2",
         "dpc-sdp/tide_api": "3.0.14",
         "dpc-sdp/tide_authenticated_content": "3.0.8",
-        "dpc-sdp/tide_core": "3.2.15-p1",
+        "dpc-sdp/tide_core": "3.2.14-p1",
         "dpc-sdp/tide_demo_content": "3.0.13",
         "dpc-sdp/tide_event": "3.0.4",
         "dpc-sdp/tide_event_atdw": "3.0.1",


### PR DESCRIPTION
Changes

1. Update `tide_core` to use https://github.com/dpc-sdp/tide_core/releases/tag/3.2.14-p1
This is done as to prevent `vicpol` to get changes from content that was pushed into `develolp` for the `1.47.0` release.
Only changes from the `tide_core` commits as listed below are required.

`9bc3479410235cfefa0df62086196e3ab25e6a32`
`ed0c3cdc0ae47348cdc9c2e22238896b2adb013d`
`a564086a960f88724a437ee392c84a81377416e9`

This will be used only for `content-vicpol` `1.46.x` release.

The TAG `3.2.23-p1` will be created used only for `content-vicpol` `1.46.x` release.
Will not be released in tide.